### PR TITLE
Update Lazy.nvim config in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,7 @@ Install this plugin using your favorite plugin manager, and then call
     "kylechui/nvim-surround",
     version = "^3.0.0", -- Use for stability; omit to use `main` branch for the latest features
     event = "VeryLazy",
-    config = function()
-        require("nvim-surround").setup({
-            -- Configuration here, or leave empty to use defaults
-        })
-    end
+    opts = {},
 }
 ```
 


### PR DESCRIPTION
`opts` are passed to M.setup() since lazy v9